### PR TITLE
Add why & remove ETA from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Something doesn't work.
 title: ''
-labels: "bug \U0001F41B"
+labels: "bug / warning / problem ⚠️"
 assignees: ''
 
 ---
@@ -16,12 +16,16 @@ assignees: ''
 
 ## Error message or warning
 
+
 ## Expected behavior
 
+
 ## Possible solution
+
 
 ## Steps to reproduce
 1.
 2.
 3.
 4.
+

--- a/.github/ISSUE_TEMPLATE/data-or-modeling.md
+++ b/.github/ISSUE_TEMPLATE/data-or-modeling.md
@@ -1,19 +1,21 @@
 ---
-name: Data or modeling
-about: Format data, train a model, call explore.
+name: Data or analysis
+about: Curate or analyze data.
 title: ''
-labels: "data \U0001F4C8 or modeling \U0001F9E0"
+labels: "data or analysis 🧠"
 assignees: ''
 
 ---
 
-## Context
+## What (keep it short)
+
+
+## Why
+
 
 ## Completion criteria
 - [ ] Step 1
 - [ ] Step 2
 
 ## Blocked by or pending
-
-## Expected completion date
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,13 +1,17 @@
 ---
 name: Documentation
-about: Document workflow or data in Notion (Atlas) or GitHub (README).
+about: Document workflow or data.
 title: ''
 labels: "documentation 📝"
 assignees: ''
 
 ---
 
-## Context
+## What (keep it short)
+
+
+## Why
+
 
 ## Completion criteria
 - [ ] Step 1
@@ -15,5 +19,4 @@ assignees: ''
 
 ## Blocked by or pending
 
-## Expected completion date
 

--- a/.github/ISSUE_TEMPLATE/question-or-idea.md
+++ b/.github/ISSUE_TEMPLATE/question-or-idea.md
@@ -1,8 +1,8 @@
 ---
-name: Infrastructure
-about: New functionality or enhancements.
-title: ''
-labels: "infrastructure 🏗"
+name: Question or Idea
+about: "Question or Idea" 
+title: 'Question or Idea'
+labels: "question ❓/ idea 💡"
 assignees: ''
 
 ---
@@ -18,4 +18,5 @@ assignees: ''
 - [ ] Step 2
 
 ## Blocked by or pending
+
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,12 +3,11 @@ Closes #
 
 ## Changelog
 - [x] 
-- [ ] todo: 
+- [ ] todo:
 
-## Checklist
-- [ ] The following are complete:
-    - Added or revised tests if appropriate.
-    - If new packages are installed, `requirements.txt` is updated.
-    - Documentation is updated, or a documentation issue has been made.
-    - The PR name describes its content and does not contain "Ref #".
-    - The PR does not add PHI.
+# BEFORE SUBMITTING THIS PR, PLEASE FILL IN METADATA TO THE RIGHT COLUMN:
+- REVIEWER
+- ASSIGNEE (USUALLY YOU)
+- LABELS
+- PROJECTS (SELECT DSE)
+THEN DELETE THIS MARKDOWN TEXT


### PR DESCRIPTION
## Issues closed
No issue

## Changelog
- [x] Remove `Expected due date` from issue templates (this info now in the `Projects -> iteration` field in the right column)
- [x] Add `Why` section to issue templates